### PR TITLE
plugin/localbinary: Exit output stream goroutines when plugin closes

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin_test.go
+++ b/libmachine/drivers/plugin/localbinary/plugin_test.go
@@ -71,10 +71,10 @@ func TestLocalBinaryPluginAddressTimeout(t *testing.T) {
 
 func TestLocalBinaryPluginClose(t *testing.T) {
 	lbp := &Plugin{}
-	lbp.stopCh = make(chan bool, 1)
+	lbp.stopCh = make(chan struct{})
 	go lbp.Close()
-	stopped := <-lbp.stopCh
-	if !stopped {
+	_, isOpen := <-lbp.stopCh
+	if isOpen {
 		t.Fatal("Close did not send a stop message on the proper channel")
 	}
 }
@@ -106,7 +106,7 @@ func TestExecServer(t *testing.T) {
 		MachineName: machineName,
 		Executor:    fe,
 		addrCh:      make(chan string, 1),
-		stopCh:      make(chan bool, 1),
+		stopCh:      make(chan struct{}),
 	}
 
 	finalErr := make(chan error)


### PR DESCRIPTION
A similar PR was sent to the official repo in docker/machine#4629 but since it's in maintenance mode I'm also sending it here.

This commit ensures that when a plugin instance is closed the goroutines responsible for streaming stdout and stderr of the called binary will also exit, preventing a goroutines leak.

Before this commit these goroutines could stay blocked forever if Close() was called while the binary still had some pending output.

I found this bug after debugging a real world goroutine leak, the goroutines dump would show thousands of goroutines stuck at:

```
github.com/tsuru/tsuru/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary.stream(0xc023013d80, 0xc0000aad20)
	/home/travis/gopath/src/github.com/tsuru/tsuru/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary/plugin.go:177 +0x7c
created by github.com/tsuru/tsuru/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary.(*Plugin).AttachStream
	/home/travis/gopath/src/github.com/tsuru/tsuru/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary/plugin.go:183 +0x67
```
