### PR TITLE
Fix broken IsVTXDisabled detection on AMD CPU

### DIFF
--- a/drivers/virtualbox/vtx_intel.go
+++ b/drivers/virtualbox/vtx_intel.go
@@ -6,7 +6,7 @@ import "github.com/intel-go/cpuid"
 
 // IsVTXDisabled checks if VT-x is disabled in the CPU.
 func (d *Driver) IsVTXDisabled() bool {
-	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasFeature(cpuid.SVM) {
+	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasExtraFeature(cpuid.SVM) {
 		return false
 	}
 


### PR DESCRIPTION
VMX is in FeatureNames, but SVM is in ExtraFeatureNames
This meant that detection *always* failed for SVM (AMD)