### PR TITLE
Update machine-drivers/machine to docker/machine

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -27,11 +27,6 @@
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
 
-	[people.dgageot]
-	Name = "David Gageot"
-	Email = "david.gageot@docker.com"
-	GitHub = "dgageot"
-
 	[people.jeanlaurent]
 	Name = "Jean-Laurent de Morlhon"
 	Email = "jeanlaurent@docker.com"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13,9 +13,12 @@
 		people = [
 			"dgageot",
 			"jeanlaurent",
-			"shin-",
 		]
 
+	[Org.Alumni]
+		people = [
+			"shin-",
+		]
 [people]
 
 # A reference list of all people associated with the project.
@@ -36,5 +39,5 @@
 
 	[people.shin-]
 	Name = "Joffrey F"
-	Email = "joffrey@docker.com"
+	Email = "f.joffrey@gmail.com"
 	GitHub = "shin-"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,7 +11,6 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-			"dgageot",
 			"jeanlaurent",
 		]
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -39,6 +39,7 @@ const (
 	defaultVolumeType           = "gp2"
 	defaultZone                 = "a"
 	defaultSecurityGroup        = machineSecurityGroupName
+	defaultSSHPort              = 22
 	defaultSSHUser              = "ubuntu"
 	defaultSpotPrice            = "0.50"
 	defaultBlockDurationMinutes = 0
@@ -203,9 +204,15 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "AWS IAM Instance Profile",
 			EnvVar: "AWS_INSTANCE_PROFILE",
 		},
+		mcnflag.IntFlag{
+			Name:   "amazonec2-ssh-port",
+			Usage:  "SSH port",
+			Value:  defaultSSHPort,
+			EnvVar: "AWS_SSH_PORT",
+		},
 		mcnflag.StringFlag{
 			Name:   "amazonec2-ssh-user",
-			Usage:  "Set the name of the ssh user",
+			Usage:  "SSH username",
 			Value:  defaultSSHUser,
 			EnvVar: "AWS_SSH_USER",
 		},
@@ -286,6 +293,7 @@ func NewDriver(hostName, storePath string) *Driver {
 		SpotPrice:            defaultSpotPrice,
 		BlockDurationMinutes: defaultBlockDurationMinutes,
 		BaseDriver: &drivers.BaseDriver{
+			SSHPort:     defaultSSHPort,
 			SSHUser:     defaultSSHUser,
 			MachineName: hostName,
 			StorePath:   storePath,
@@ -354,7 +362,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.VolumeType = flags.String("amazonec2-volume-type")
 	d.IamInstanceProfile = flags.String("amazonec2-iam-instance-profile")
 	d.SSHUser = flags.String("amazonec2-ssh-user")
-	d.SSHPort = 22
+	d.SSHPort = flags.Int("amazonec2-ssh-port")
 	d.PrivateIPOnly = flags.Bool("amazonec2-private-address-only")
 	d.UsePrivateIP = flags.Bool("amazonec2-use-private-address")
 	d.Monitoring = flags.Bool("amazonec2-monitoring")
@@ -817,6 +825,14 @@ func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
 }
 
+func (d *Driver) GetSSHPort() (int, error) {
+	if d.SSHPort == 0 {
+		d.SSHPort = defaultSSHPort
+	}
+
+	return d.SSHPort, nil
+}
+
 func (d *Driver) GetSSHUsername() string {
 	if d.SSHUser == "" {
 		d.SSHUser = defaultSSHUser
@@ -1119,11 +1135,11 @@ func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) ([]
 
 	perms := []*ec2.IpPermission{}
 
-	if !hasPorts["22/tcp"] {
+	if !hasPorts[fmt.Sprintf("%d/tcp", d.BaseDriver.SSHPort)] {
 		perms = append(perms, &ec2.IpPermission{
 			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int64(22),
-			ToPort:     aws.Int64(22),
+			FromPort:   aws.Int64(int64(d.BaseDriver.SSHPort)),
+			ToPort:     aws.Int64(int64(d.BaseDriver.SSHPort)),
 			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(ipRange)}},
 		})
 	}

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -19,6 +19,7 @@ var regionDetails map[string]*region = map[string]*region{
 	"ca-central-1":    {"ami-8d9e19e9"},
 	"cn-north-1":      {"ami-cc4499a1"}, // Note: this is 20180126
 	"cn-northwest-1":  {"ami-fd0e1a9f"}, // Note: this is 20180126
+	"eu-north-1":      {"ami-017ff17f"},
 	"eu-central-1":    {"ami-bc4925d3"},
 	"eu-west-1":       {"ami-0b541372"},
 	"eu-west-2":       {"ami-ff46a298"},

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -265,7 +265,7 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		},
 		ServiceAccounts: []*raw.ServiceAccount{
 			{
-				Email:  "default",
+				Email:  d.ServiceAccount,
 				Scopes: strings.Split(d.Scopes, ","),
 			},
 		},

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -26,6 +26,7 @@ type Driver struct {
 	Preemptible       bool
 	UseInternalIP     bool
 	UseInternalIPOnly bool
+	ServiceAccount    string
 	Scopes            string
 	DiskSize          int
 	Project           string
@@ -35,15 +36,16 @@ type Driver struct {
 }
 
 const (
-	defaultZone        = "us-central1-a"
-	defaultUser        = "docker-user"
-	defaultMachineType = "n1-standard-1"
-	defaultImageName   = "ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20170721"
-	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write"
-	defaultDiskType    = "pd-standard"
-	defaultDiskSize    = 10
-	defaultNetwork     = "default"
-	defaultSubnetwork  = ""
+	defaultZone           = "us-central1-a"
+	defaultUser           = "docker-user"
+	defaultMachineType    = "n1-standard-1"
+	defaultImageName      = "ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20170721"
+	defaultServiceAccount = "default"
+	defaultScopes         = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write"
+	defaultDiskType       = "pd-standard"
+	defaultDiskSize       = 10
+	defaultNetwork        = "default"
+	defaultSubnetwork     = ""
 )
 
 // GetCreateFlags registers the flags this driver adds to
@@ -78,6 +80,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "google-project",
 			Usage:  "GCE Project",
 			EnvVar: "GOOGLE_PROJECT",
+		},
+		mcnflag.StringFlag{
+			Name:   "google-service-account",
+			Usage:  "GCE Service Account for the VM (email address)",
+			Value:  defaultServiceAccount,
+			EnvVar: "GOOGLE_SERVICE_ACCOUNT",
 		},
 		mcnflag.StringFlag{
 			Name:   "google-scopes",
@@ -150,14 +158,15 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 // NewDriver creates a Driver with the specified storePath.
 func NewDriver(machineName string, storePath string) *Driver {
 	return &Driver{
-		Zone:         defaultZone,
-		DiskType:     defaultDiskType,
-		DiskSize:     defaultDiskSize,
-		MachineType:  defaultMachineType,
-		MachineImage: defaultImageName,
-		Network:      defaultNetwork,
-		Subnetwork:   defaultSubnetwork,
-		Scopes:       defaultScopes,
+		Zone:           defaultZone,
+		DiskType:       defaultDiskType,
+		DiskSize:       defaultDiskSize,
+		MachineType:    defaultMachineType,
+		MachineImage:   defaultImageName,
+		Network:        defaultNetwork,
+		Subnetwork:     defaultSubnetwork,
+		ServiceAccount: defaultServiceAccount,
+		Scopes:         defaultScopes,
 		BaseDriver: &drivers.BaseDriver{
 			SSHUser:     defaultUser,
 			MachineName: machineName,
@@ -205,6 +214,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.Preemptible = flags.Bool("google-preemptible")
 		d.UseInternalIP = flags.Bool("google-use-internal-ip") || flags.Bool("google-use-internal-ip-only")
 		d.UseInternalIPOnly = flags.Bool("google-use-internal-ip-only")
+		d.ServiceAccount = flags.String("google-service-account")
 		d.Scopes = flags.String("google-scopes")
 		d.Tags = flags.String("google-tags")
 		d.OpenPorts = flags.StringSlice("google-open-port")

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -273,7 +273,7 @@ func (d *Driver) Create() error {
 func (d *Driver) chooseVirtualSwitch() (string, error) {
 	if d.VSwitch == "" {
 		// Default to the first external switche and in the process avoid DockerNAT
-		stdout, err := cmdOut("(Hyper-V\\Get-VMSwitch -SwitchType External).Name")
+		stdout, err := cmdOut("[Console]::OutputEncoding = [Text.Encoding]::UTF8; (Hyper-V\\Get-VMSwitch -SwitchType External).Name")
 		if err != nil {
 			return "", err
 		}
@@ -287,7 +287,7 @@ func (d *Driver) chooseVirtualSwitch() (string, error) {
 		return switches[0], nil
 	}
 
-	stdout, err := cmdOut("(Hyper-V\\Get-VMSwitch).Name")
+	stdout, err := cmdOut("[Console]::OutputEncoding = [Text.Encoding]::UTF8; (Hyper-V\\Get-VMSwitch).Name")
 	if err != nil {
 		return "", err
 	}

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -69,6 +69,7 @@ func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 		SecurityGroups:   d.SecurityGroups,
 		AvailabilityZone: d.AvailabilityZone,
 		ConfigDrive:      d.ConfigDrive,
+		Metadata:         d.GetMetadata(),
 	}
 	if d.NetworkId != "" {
 		serverOpts.Networks = []servers.Network{

--- a/drivers/softlayer/softlayer.go
+++ b/drivers/softlayer/softlayer.go
@@ -114,7 +114,6 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 	}
 
 	req.SetBasicAuth(c.User, c.ApiKey)
-	req.Method = method
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/drivers/virtualbox/vtx_intel.go
+++ b/drivers/virtualbox/vtx_intel.go
@@ -6,7 +6,7 @@ import "github.com/intel-go/cpuid"
 
 // IsVTXDisabled checks if VT-x is disabled in the CPU.
 func (d *Driver) IsVTXDisabled() bool {
-	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasFeature(cpuid.SVM) {
+	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasExtraFeature(cpuid.SVM) {
 		return false
 	}
 

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -436,7 +436,7 @@ func (d *Driver) Start() error {
 			return err
 		} else if !os.IsNotExist(err) {
 			// create mountpoint and mount shared folder
-			command := "([ ! -d " + shareDir + " ]&& sudo mkdir " + shareDir + "; sudo mount --bind /mnt/hgfs/" + shareDir + " " + shareDir + ") || ([ -f /usr/local/bin/vmhgfs-fuse ]&& sudo /usr/local/bin/vmhgfs-fuse -o allow_other .host:/" + shareName + " " + shareDir + ") || sudo mount -t vmhgfs -o uid=$(id -u),gid=$(id -g) .host:/" + shareName + " " + shareDir
+			command := "([ ! -d " + shareDir + " ]&& sudo mkdir " + shareDir + "; sudo mount --bind /mnt/hgfs/" + shareDir + " " + shareDir + ") || ([ -f /usr/local/bin/vmhgfs-fuse ]&& sudo /usr/local/bin/vmhgfs-fuse -o nonempty -o allow_other .host:/" + shareName + " " + shareDir + ") || sudo mount -t vmhgfs -o uid=$(id -u),gid=$(id -g) .host:/" + shareName + " " + shareDir
 			vmrun("-gu", B2DUser, "-gp", B2DPass, "runScriptInGuest", d.vmxPath(), "/bin/sh", command)
 		}
 	}

--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -94,7 +94,7 @@ func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOp
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/arch_test.go
+++ b/libmachine/provision/arch_test.go
@@ -14,7 +14,7 @@ func TestArchDefaultStorageDriver(t *testing.T) {
 	p := NewArchProvisioner(&fakedriver.Driver{}).(*ArchProvisioner)
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "overlay" {
-		t.Fatal("Default storage driver should be overlay")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }


### PR DESCRIPTION
This includes the two fixes, added downstream:

- 6f34be4 "Allow localized names for Virtual Switch" (https://github.com/docker/machine/pull/4509)
- 3a0d935 "Fix broken IsVTXDisabled detection on AMD CPU" (https://github.com/docker/machine/pull/4679)

This means that there are no more differences...

After this, we _could_ force-push `master` (drop rebases) ?

github.com/docker/machine
a555e4f7a8f518a8b1b174824c377e46cbfc4fe2

Same idea as #15 (from March), but now with updates.