### PR TITLE
Make few members of the Hyper-V Package Exportable

### DIFF
--- a/cmd/docker-machine/machine.go
+++ b/cmd/docker-machine/machine.go
@@ -7,7 +7,7 @@ import (
 
 	"path/filepath"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/docker/machine/commands"
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/drivers/amazonec2"

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/crashreport"

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/docker/machine/commands/commandstest"
 	"github.com/docker/machine/drivers/fakedriver"
 	"github.com/docker/machine/libmachine"

--- a/commands/commandstest/fake_command_line.go
+++ b/commands/commandstest/fake_command_line.go
@@ -1,7 +1,7 @@
 package commandstest
 
 import (
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 type FakeFlagger struct {

--- a/commands/create.go
+++ b/commands/create.go
@@ -14,7 +14,7 @@ import (
 
 	"time"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/auth"

--- a/commands/flag_sort.go
+++ b/commands/flag_sort.go
@@ -1,6 +1,6 @@
 package commands
 
-import "github.com/codegangsta/cli"
+import "github.com/urfave/cli"
 
 type ByFlagName []cli.Flag
 

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -505,3 +505,27 @@ func (d *Driver) generateDiskImage() (string, error) {
 
 	return diskImage, nil
 }
+
+func (path string) EnableCifsShare() (bool, error) {
+	// Ensure that the current user is administrator because creating a SMB Share requires Administrator privileges.
+	_ , err := isWindowsAdministrator()
+	if err != nil {
+		return false, err
+	}
+
+	// Get the current user so that we can assign full access permissions to only that user.
+	// TODO - Check if we can use another user.
+	user, err := getCurrentWindowsUser()
+	if err != nil {
+		return false, err
+	}
+
+	log.Info("Trying to enable share for CIFS Mounting.")
+
+	var shareName = "minikube"
+	if err := cmd("SmbShare\\New-SmbShare", "-Name", shareName, "-Path", path , "-FullAccess", user, "-Temporary", ); err != nil {
+		return false, err
+	}
+
+	return true,nil
+}

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -105,6 +105,17 @@ func isWindowsAdministrator() (bool, error) {
 	return resp[0] == "True", nil
 }
 
+// This function is used to get the full name of the current user trying to run. It will be DOMAIN\Username or MACHINE_NAME\Username
+// TODO - Check if CIFS shares can be used by people who have domain accounts and are local admins on their machines.
+func getCurrentWindowsUser() (string, error) {
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).Identities.Name`)
+	if err != nil {
+		return "", err
+	}
+	response := parseLines(stdout)
+	return response[0], nil
+}
+
 func quote(text string) string {
 	return fmt.Sprintf("'%s'", text)
 }

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -38,12 +38,12 @@ func cmdOut(args ...string) (string, error) {
 	return stdout.String(), err
 }
 
-func cmd(args ...string) error {
+func Cmd(args ...string) error {
 	_, err := cmdOut(args...)
 	return err
 }
 
-func parseLines(stdout string) []string {
+func ParseLines(stdout string) []string {
 	resp := []string{}
 
 	s := bufio.NewScanner(strings.NewReader(stdout))
@@ -60,7 +60,7 @@ func hypervAvailable() error {
 		return err
 	}
 
-	resp := parseLines(stdout)
+	resp := ParseLines(stdout)
 	if resp[0] != "Hyper-V" {
 		return ErrNotInstalled
 	}
@@ -75,7 +75,7 @@ func isAdministrator() (bool, error) {
 		return true, nil
 	}
 
-	windowsAdmin, err := isWindowsAdministrator()
+	windowsAdmin, err := IsWindowsAdministrator()
 
 	if err != nil {
 		return false, err
@@ -91,28 +91,28 @@ func isHypervAdministrator() bool {
 		return false
 	}
 
-	resp := parseLines(stdout)
+	resp := ParseLines(stdout)
 	return resp[0] == "True"
 }
 
-func isWindowsAdministrator() (bool, error) {
+func IsWindowsAdministrator() (bool, error) {
 	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")`)
 	if err != nil {
 		return false, err
 	}
 
-	resp := parseLines(stdout)
+	resp := ParseLines(stdout)
 	return resp[0] == "True", nil
 }
 
 // This function is used to get the full name of the current user trying to run. It will be DOMAIN\Username or MACHINE_NAME\Username
 // TODO - Check if CIFS shares can be used by people who have domain accounts and are local admins on their machines.
-func getCurrentWindowsUser() (string, error) {
+func GetCurrentWindowsUser() (string, error) {
 	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).Identities.Name`)
 	if err != nil {
 		return "", err
 	}
-	response := parseLines(stdout)
+	response := ParseLines(stdout)
 	return response[0], nil
 }
 


### PR DESCRIPTION
## Description

This PR makes few of the methods public in the package so that it is easier to re-use the methods in minikube. Also, helps with the CIFS Mounting work for Hyper-V.

The `github.com/codegangsta/cli` package has been renamed to `github.com/urfave/cli`

/cc: @tstromberg, @sharifelgamal, @afbjorklund