### PR TITLE
Fix Windows minikube ISO download

### DIFF
--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/docker/machine/libmachine/log"
@@ -196,7 +197,11 @@ func (*b2dReleaseGetter) download(dir, file, isoURL string) error {
 
 	var src io.ReadCloser
 	if u.Scheme == "file" || u.Scheme == "" {
-		s, err := os.Open(u.Path)
+		path := u.Path
+		if runtime.GOOS == "windows" {
+			path = u.Hostname() + ":/" + u.Path
+		}
+		s, err := os.Open(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- On Windows, `minikube` passes in a file URL like `"file://C:/Users/douglas/.minikube/cache/iso/minikube-v1.2.0.iso"`,
  however, due to the way that Go parses URLs, the `"C:"` part is actually
  parsed as the hostname portion instead of staying at the beginning of
  the path (golang/go#6027). If `minikube` is run with a working directory on a different drive
  from where its cache directory resides, it will fail since
  `libmachine` is only looking at the path portion (in this case:
  `"/Users/douglas/.minikube/cache/iso/minikube-v1.2.0.iso"`) so it
  fails to find the file (kubernetes/minikube#1574).

Signed-off-by: Douglas Thrift <dthrift@flexera.com>
(cherry picked from commit ade55018264a1cde51c0c77bed184a0d528759f9)

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
