### PR TITLE
Fix HyperV Administrator check

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -85,7 +85,7 @@ func isAdministrator() (bool, error) {
 }
 
 func isHypervAdministrator() bool {
-	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("S-1-5-32-578")`)
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(([System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-578")))`)
 	if err != nil {
 		log.Debug(err)
 		return false


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description
Fix "HyperV Administrator" role check.

IsInRole() parameter should be either a group name [String] with potential I18N issues (the group name may change), or an SID [SecurityIdentifier]. Using a SID as a String doesn't work.

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
