### PR TITLE
Fix missing Virtual Switch in Config with Hyper-V

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -205,12 +205,14 @@ func (d *Driver) Create() error {
 	}
 
 	log.Infof("Creating VM...")
-	virtualSwitch, err := d.chooseVirtualSwitch()
-	if err != nil {
-		return err
+	if d.VSwitch == "" {
+		defaultVSwitch, err := d.chooseVirtualSwitch()
+		if err != nil {
+			return err
+		}
+		d.VSwitch = defaultVSwitch
 	}
-
-	log.Infof("Using switch %q", virtualSwitch)
+	log.Infof("Using switch %q", d.VSwitch)
 
 	diskImage, err := d.generateDiskImage()
 	if err != nil {
@@ -220,7 +222,7 @@ func (d *Driver) Create() error {
 	if err := cmd("Hyper-V\\New-VM",
 		d.MachineName,
 		"-Path", fmt.Sprintf("'%s'", d.ResolveStorePath(".")),
-		"-SwitchName", quote(virtualSwitch),
+		"-SwitchName", quote(d.VSwitch),
 		"-MemoryStartupBytes", toMb(d.MemSize)); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->
This Pull request sets the VSwitch at the driver level after getting the best available switch from `chooseVirtualSwitch()`.

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
This Pull Request fixes the issue mentioned over here - https://github.com/kubernetes/minikube/issues/5672
