### PR TITLE
Update machine-drivers/machine to docker/machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0
+FROM golang:1.12.9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
                 openssh-client \


### PR DESCRIPTION
Just a minor update, to bring the version to v0.16.2 (2 Sep 2019)

https://github.com/docker/machine/releases/tag/v0.16.2

No big changes, just updating go version in default make container...

* 9f4d13b30d1a6b23896878a60a04bdec03834922 Update golang 1.12.9

This repository now has the following 4 patches applied downstream.

* fa999bcf953d44d9b51c0ed9ad0783cabc7a5422 Added selection of default VSwitch to config
* af52a576ff5cad9dbb7252dd0f6ad67915c7b9c9 Fix HyperV Administrator check
* bf26ea93c9d9c15c2b377e636a1aef6ee8ba94a7 Fix Windows minikube ISO download (https://github.com/docker/machine/pull/4734)
* 21bd2f51b8eacb135995c69bdf28b432333dd8e3 Use switch ID to match default switch (https://github.com/docker/machine/pull/4732)
* 2438fc956300d232c0d6715cd51a91d1d1e25d08 Hyper-V: Use Default Switch vSwitch by default (https://github.com/docker/machine/pull/4732)

The rest are just merges and rebases, even if it says "24 commits":

https://github.com/docker/machine/compare/master...machine-drivers:master