### PR TITLE
don't panic if hyper-v isn't enabled

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -61,7 +61,7 @@ func hypervAvailable() error {
 	}
 
 	resp := parseLines(stdout)
-	if resp[0] != "Hyper-V" {
+	if resp == nil || resp[0] != "Hyper-V" {
 		return ErrNotInstalled
 	}
 

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -61,7 +61,7 @@ func hypervAvailable() error {
 	}
 
 	resp := parseLines(stdout)
-	if resp == nil || resp[0] != "Hyper-V" {
+	if resp == nil || len(resp) == 0 || resp[0] != "Hyper-V" {
 		return ErrNotInstalled
 	}
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description
When checking if Hyper-V is available, we call `Get-Module -ListAvailable hyper-v` which can come back empty in certain situations. This causes a panic on the following line. We should just error out gracefully.
<!-- In a couple sentences, explain what your PR does and what problem it fixes -->


## Related issue(s)
https://github.com/kubernetes/minikube/issues/8245
https://github.com/kubernetes/minikube/issues/2954
<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
