### PR TITLE
Fix ssh key permissions in windows

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -155,6 +155,70 @@
   revision = "0bbddae09c5a5419a8c6dcdd7ff90da3d450393b"
 
 [[projects]]
+  digest = "1:e5eaa6c6fac285fceebc9647df96e3df424ba249517b54e95a18be518e8a1224"
+  name = "github.com/docker/machine"
+  packages = [
+    "commands",
+    "commands/commandstest",
+    "commands/mcndirs",
+    "drivers/amazonec2",
+    "drivers/azure",
+    "drivers/azure/azureutil",
+    "drivers/azure/logutil",
+    "drivers/digitalocean",
+    "drivers/driverutil",
+    "drivers/errdriver",
+    "drivers/exoscale",
+    "drivers/fakedriver",
+    "drivers/generic",
+    "drivers/google",
+    "drivers/hyperv",
+    "drivers/none",
+    "drivers/openstack",
+    "drivers/rackspace",
+    "drivers/softlayer",
+    "drivers/virtualbox",
+    "drivers/vmwarefusion",
+    "drivers/vmwarevcloudair",
+    "drivers/vmwarevsphere",
+    "its",
+    "libmachine",
+    "libmachine/auth",
+    "libmachine/cert",
+    "libmachine/check",
+    "libmachine/crashreport",
+    "libmachine/drivers",
+    "libmachine/drivers/plugin",
+    "libmachine/drivers/plugin/localbinary",
+    "libmachine/drivers/rpc",
+    "libmachine/engine",
+    "libmachine/host",
+    "libmachine/hosttest",
+    "libmachine/libmachinetest",
+    "libmachine/log",
+    "libmachine/mcndockerclient",
+    "libmachine/mcnerror",
+    "libmachine/mcnflag",
+    "libmachine/mcnutils",
+    "libmachine/persist",
+    "libmachine/provision",
+    "libmachine/provision/pkgaction",
+    "libmachine/provision/provisiontest",
+    "libmachine/provision/serviceaction",
+    "libmachine/shell",
+    "libmachine/ssh",
+    "libmachine/ssh/sshtest",
+    "libmachine/state",
+    "libmachine/swarm",
+    "libmachine/version",
+    "libmachine/versioncmp",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "bd45ab13d88c32a3dd701485983354514abc41fa"
+  version = "v0.16.2"
+
+[[projects]]
   digest = "1:7515ee368d2554cccaecdb552cf602e7a555139ffe45aad7500294fc14bcf2e1"
   name = "github.com/exoscale/egoscale"
   packages = ["."]
@@ -182,6 +246,17 @@
   packages = ["query"]
   pruneopts = "UT"
   revision = "30f7a39f4a218feb5325f3aebc60c32a572a8274"
+
+[[projects]]
+  branch = "master"
+  digest = "1:239338f6f78884213107067789aed51ede5ee34ce3bd126592574b5a7b713cfb"
+  name = "github.com/hectane/go-acl"
+  packages = [
+    ".",
+    "api",
+  ]
+  pruneopts = "UT"
+  revision = "da78bae5fc95895d8855ed8c5b1505b10e254450"
 
 [[projects]]
   branch = "master"
@@ -445,7 +520,63 @@
     "github.com/codegangsta/cli",
     "github.com/digitalocean/godo",
     "github.com/docker/docker/pkg/term",
+    "github.com/docker/machine/commands",
+    "github.com/docker/machine/commands/commandstest",
+    "github.com/docker/machine/commands/mcndirs",
+    "github.com/docker/machine/drivers/amazonec2",
+    "github.com/docker/machine/drivers/azure",
+    "github.com/docker/machine/drivers/azure/azureutil",
+    "github.com/docker/machine/drivers/azure/logutil",
+    "github.com/docker/machine/drivers/digitalocean",
+    "github.com/docker/machine/drivers/driverutil",
+    "github.com/docker/machine/drivers/errdriver",
+    "github.com/docker/machine/drivers/exoscale",
+    "github.com/docker/machine/drivers/fakedriver",
+    "github.com/docker/machine/drivers/generic",
+    "github.com/docker/machine/drivers/google",
+    "github.com/docker/machine/drivers/hyperv",
+    "github.com/docker/machine/drivers/none",
+    "github.com/docker/machine/drivers/openstack",
+    "github.com/docker/machine/drivers/rackspace",
+    "github.com/docker/machine/drivers/softlayer",
+    "github.com/docker/machine/drivers/virtualbox",
+    "github.com/docker/machine/drivers/vmwarefusion",
+    "github.com/docker/machine/drivers/vmwarevcloudair",
+    "github.com/docker/machine/drivers/vmwarevsphere",
+    "github.com/docker/machine/its",
+    "github.com/docker/machine/libmachine",
+    "github.com/docker/machine/libmachine/auth",
+    "github.com/docker/machine/libmachine/cert",
+    "github.com/docker/machine/libmachine/check",
+    "github.com/docker/machine/libmachine/crashreport",
+    "github.com/docker/machine/libmachine/drivers",
+    "github.com/docker/machine/libmachine/drivers/plugin",
+    "github.com/docker/machine/libmachine/drivers/plugin/localbinary",
+    "github.com/docker/machine/libmachine/drivers/rpc",
+    "github.com/docker/machine/libmachine/engine",
+    "github.com/docker/machine/libmachine/host",
+    "github.com/docker/machine/libmachine/hosttest",
+    "github.com/docker/machine/libmachine/libmachinetest",
+    "github.com/docker/machine/libmachine/log",
+    "github.com/docker/machine/libmachine/mcndockerclient",
+    "github.com/docker/machine/libmachine/mcnerror",
+    "github.com/docker/machine/libmachine/mcnflag",
+    "github.com/docker/machine/libmachine/mcnutils",
+    "github.com/docker/machine/libmachine/persist",
+    "github.com/docker/machine/libmachine/provision",
+    "github.com/docker/machine/libmachine/provision/pkgaction",
+    "github.com/docker/machine/libmachine/provision/provisiontest",
+    "github.com/docker/machine/libmachine/provision/serviceaction",
+    "github.com/docker/machine/libmachine/shell",
+    "github.com/docker/machine/libmachine/ssh",
+    "github.com/docker/machine/libmachine/ssh/sshtest",
+    "github.com/docker/machine/libmachine/state",
+    "github.com/docker/machine/libmachine/swarm",
+    "github.com/docker/machine/libmachine/version",
+    "github.com/docker/machine/libmachine/versioncmp",
+    "github.com/docker/machine/version",
     "github.com/exoscale/egoscale",
+    "github.com/hectane/go-acl",
     "github.com/intel-go/cpuid",
     "github.com/rackspace/gophercloud",
     "github.com/rackspace/gophercloud/openstack",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,3 +37,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/hectane/go-acl"

--- a/libmachine/ssh/keys.go
+++ b/libmachine/ssh/keys.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 
 	gossh "golang.org/x/crypto/ssh"
+	"github.com/hectane/go-acl"
 )
 
 var (
@@ -86,6 +87,10 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 			if err := f.Chmod(0600); err != nil {
 				return err
 			}
+		case "windows":
+			if err = windowsChmod(v.File, 0600); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -122,3 +127,12 @@ func GenerateSSHKey(path string) error {
 
 	return nil
 }
+
+// change windows acl based permissions on file
+func windowsChmod(filePath string, fileMode os.FileMode) error {
+	if err := acl.Chmod(filePath, fileMode); err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/vendor/github.com/hectane/go-acl/LICENSE.txt
+++ b/vendor/github.com/hectane/go-acl/LICENSE.txt
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Nathan Osman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/hectane/go-acl/README.md
+++ b/vendor/github.com/hectane/go-acl/README.md
@@ -1,0 +1,66 @@
+## go-acl
+
+[![Build status](https://ci.appveyor.com/api/projects/status/rbdyu7c39o2j0ru9?svg=true)](https://ci.appveyor.com/project/nathan-osman/go-acl)
+[![GoDoc](https://godoc.org/github.com/hectane/go-acl?status.svg)](https://godoc.org/github.com/hectane/go-acl)
+[![MIT License](http://img.shields.io/badge/license-MIT-9370d8.svg?style=flat)](http://opensource.org/licenses/MIT)
+
+Manipulating ACLs (Access Control Lists) on Windows is difficult. go-acl wraps the Windows API functions that control access to objects, simplifying the process.
+
+### Using the Package
+
+To use the package add the following imports:
+
+    import (
+        "github.com/hectane/go-acl"
+        "golang.org/x/sys/windows"
+    )
+
+### Examples
+
+Probably the most commonly used function in this package is `Chmod`:
+
+    if err := acl.Chmod("C:\\path\\to\\file.txt", 0755); err != nil {
+        panic(err)
+    }
+
+To grant read access to user "Alice" and deny write access to user "Bob":
+
+    if err := acl.Apply(
+        "C:\\path\\to\\file.txt",
+        false,
+        false,
+        acl.GrantName(windows.GENERIC_READ, "Alice"),
+        acl.DenyName(windows.GENERIC_WRITE, "Bob"),
+    ); err != nil {
+        panic(err)
+    }
+
+### Using the API Directly
+
+go-acl's `api` package exposes the individual Windows API functions that are used to manipulate ACLs. For example, to retrieve the current owner of a file:
+
+    import (
+        "github.com/hectane/go-acl/api"
+        "golang.org/x/sys/windows"
+    )
+
+    var (
+        owner   *windows.SID
+        secDesc windows.Handle
+    )
+    err := api.GetNamedSecurityInfo(
+        "C:\\path\\to\\file.txt",
+        api.SE_FILE_OBJECT,
+        api.OWNER_SECURITY_INFORMATION,
+        &owner,
+        nil,
+        nil,
+        nil,
+        &secDesc,
+    )
+    if err != nil {
+        panic(err)
+    }
+    defer windows.LocalFree(secDesc)
+
+`owner` will then point to the SID for the owner of the file.

--- a/vendor/github.com/hectane/go-acl/api/acl.go
+++ b/vendor/github.com/hectane/go-acl/api/acl.go
@@ -1,0 +1,98 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379284.aspx
+const (
+	NO_MULTIPLE_TRUSTEE = iota
+	TRUSTEE_IS_IMPERSONATE
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379638.aspx
+const (
+	TRUSTEE_IS_SID = iota
+	TRUSTEE_IS_NAME
+	TRUSTEE_BAD_FORM
+	TRUSTEE_IS_OBJECTS_AND_SID
+	TRUSTEE_IS_OBJECTS_AND_NAME
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379639.aspx
+const (
+	TRUSTEE_IS_UNKNOWN = iota
+	TRUSTEE_IS_USER
+	TRUSTEE_IS_GROUP
+	TRUSTEE_IS_DOMAIN
+	TRUSTEE_IS_ALIAS
+	TRUSTEE_IS_WELL_KNOWN_GROUP
+	TRUSTEE_IS_DELETED
+	TRUSTEE_IS_INVALID
+	TRUSTEE_IS_COMPUTER
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa374899.aspx
+const (
+	NOT_USED_ACCESS = iota
+	GRANT_ACCESS
+	SET_ACCESS
+	DENY_ACCESS
+	REVOKE_ACCESS
+	SET_AUDIT_SUCCESS
+	SET_AUDIT_FAILURE
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
+const (
+	NO_INHERITANCE                     = 0x0
+	SUB_OBJECTS_ONLY_INHERIT           = 0x1
+	SUB_CONTAINERS_ONLY_INHERIT        = 0x2
+	SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3
+	INHERIT_NO_PROPAGATE               = 0x4
+	INHERIT_ONLY                       = 0x8
+
+	OBJECT_INHERIT_ACE       = 0x1
+	CONTAINER_INHERIT_ACE    = 0x2
+	NO_PROPAGATE_INHERIT_ACE = 0x4
+	INHERIT_ONLY_ACE         = 0x8
+)
+
+var (
+	procSetEntriesInAclW = advapi32.MustFindProc("SetEntriesInAclW")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379636.aspx
+type Trustee struct {
+	MultipleTrustee          *Trustee
+	MultipleTrusteeOperation int32
+	TrusteeForm              int32
+	TrusteeType              int32
+	Name                     *uint16
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
+type ExplicitAccess struct {
+	AccessPermissions uint32
+	AccessMode        int32
+	Inheritance       uint32
+	Trustee           Trustee
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379576.aspx
+func SetEntriesInAcl(entries []ExplicitAccess, oldAcl windows.Handle, newAcl *windows.Handle) error {
+	ret, _, err := procSetEntriesInAclW.Call(
+		uintptr(len(entries)),
+		uintptr(unsafe.Pointer(&entries[0])),
+		uintptr(oldAcl),
+		uintptr(unsafe.Pointer(newAcl)),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/hectane/go-acl/api/api.go
+++ b/vendor/github.com/hectane/go-acl/api/api.go
@@ -1,0 +1,10 @@
+//+build windows
+
+// Windows API functions for manipulating ACLs.
+package api
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var advapi32 = windows.MustLoadDLL("advapi32.dll")

--- a/vendor/github.com/hectane/go-acl/api/posix.go
+++ b/vendor/github.com/hectane/go-acl/api/posix.go
@@ -1,0 +1,3 @@
+//+build !windows
+
+package api

--- a/vendor/github.com/hectane/go-acl/api/secinfo.go
+++ b/vendor/github.com/hectane/go-acl/api/secinfo.go
@@ -1,0 +1,84 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593.aspx
+const (
+	SE_UNKNOWN_OBJECT_TYPE = iota
+	SE_FILE_OBJECT
+	SE_SERVICE
+	SE_PRINTER
+	SE_REGISTRY_KEY
+	SE_LMSHARE
+	SE_KERNEL_OBJECT
+	SE_WINDOW_OBJECT
+	SE_DS_OBJECT
+	SE_DS_OBJECT_ALL
+	SE_PROVIDER_DEFINED_OBJECT
+	SE_WMIGUID_OBJECT
+	SE_REGISTRY_WOW64_32KEY
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379573.aspx
+const (
+	OWNER_SECURITY_INFORMATION               = 0x00001
+	GROUP_SECURITY_INFORMATION               = 0x00002
+	DACL_SECURITY_INFORMATION                = 0x00004
+	SACL_SECURITY_INFORMATION                = 0x00008
+	LABEL_SECURITY_INFORMATION               = 0x00010
+	ATTRIBUTE_SECURITY_INFORMATION           = 0x00020
+	SCOPE_SECURITY_INFORMATION               = 0x00040
+	PROCESS_TRUST_LABEL_SECURITY_INFORMATION = 0x00080
+	BACKUP_SECURITY_INFORMATION              = 0x10000
+
+	PROTECTED_DACL_SECURITY_INFORMATION   = 0x80000000
+	PROTECTED_SACL_SECURITY_INFORMATION   = 0x40000000
+	UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000
+	UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000
+)
+
+var (
+	procGetNamedSecurityInfoW = advapi32.MustFindProc("GetNamedSecurityInfoW")
+	procSetNamedSecurityInfoW = advapi32.MustFindProc("SetNamedSecurityInfoW")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446645.aspx
+func GetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group **windows.SID, dacl, sacl, secDesc *windows.Handle) error {
+	ret, _, err := procGetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
+		uintptr(objectType),
+		uintptr(secInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(sacl)),
+		uintptr(unsafe.Pointer(secDesc)),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379579.aspx
+func SetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group *windows.SID, dacl, sacl windows.Handle) error {
+	ret, _, err := procSetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
+		uintptr(objectType),
+		uintptr(secInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(dacl),
+		uintptr(sacl),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/hectane/go-acl/api/sid.go
+++ b/vendor/github.com/hectane/go-acl/api/sid.go
@@ -1,0 +1,131 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ee207397.aspx
+const (
+	SECURITY_MAX_SID_SIZE = 68
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379650.aspx
+const (
+	WinNullSid                                  = 0
+	WinWorldSid                                 = 1
+	WinLocalSid                                 = 2
+	WinCreatorOwnerSid                          = 3
+	WinCreatorGroupSid                          = 4
+	WinCreatorOwnerServerSid                    = 5
+	WinCreatorGroupServerSid                    = 6
+	WinNtAuthoritySid                           = 7
+	WinDialupSid                                = 8
+	WinNetworkSid                               = 9
+	WinBatchSid                                 = 10
+	WinInteractiveSid                           = 11
+	WinServiceSid                               = 12
+	WinAnonymousSid                             = 13
+	WinProxySid                                 = 14
+	WinEnterpriseControllersSid                 = 15
+	WinSelfSid                                  = 16
+	WinAuthenticatedUserSid                     = 17
+	WinRestrictedCodeSid                        = 18
+	WinTerminalServerSid                        = 19
+	WinRemoteLogonIdSid                         = 20
+	WinLogonIdsSid                              = 21
+	WinLocalSystemSid                           = 22
+	WinLocalServiceSid                          = 23
+	WinNetworkServiceSid                        = 24
+	WinBuiltinDomainSid                         = 25
+	WinBuiltinAdministratorsSid                 = 26
+	WinBuiltinUsersSid                          = 27
+	WinBuiltinGuestsSid                         = 28
+	WinBuiltinPowerUsersSid                     = 29
+	WinBuiltinAccountOperatorsSid               = 30
+	WinBuiltinSystemOperatorsSid                = 31
+	WinBuiltinPrintOperatorsSid                 = 32
+	WinBuiltinBackupOperatorsSid                = 33
+	WinBuiltinReplicatorSid                     = 34
+	WinBuiltinPreWindows2000CompatibleAccessSid = 35
+	WinBuiltinRemoteDesktopUsersSid             = 36
+	WinBuiltinNetworkConfigurationOperatorsSid  = 37
+	WinAccountAdministratorSid                  = 38
+	WinAccountGuestSid                          = 39
+	WinAccountKrbtgtSid                         = 40
+	WinAccountDomainAdminsSid                   = 41
+	WinAccountDomainUsersSid                    = 42
+	WinAccountDomainGuestsSid                   = 43
+	WinAccountComputersSid                      = 44
+	WinAccountControllersSid                    = 45
+	WinAccountCertAdminsSid                     = 46
+	WinAccountSchemaAdminsSid                   = 47
+	WinAccountEnterpriseAdminsSid               = 48
+	WinAccountPolicyAdminsSid                   = 49
+	WinAccountRasAndIasServersSid               = 50
+	WinNTLMAuthenticationSid                    = 51
+	WinDigestAuthenticationSid                  = 52
+	WinSChannelAuthenticationSid                = 53
+	WinThisOrganizationSid                      = 54
+	WinOtherOrganizationSid                     = 55
+	WinBuiltinIncomingForestTrustBuildersSid    = 56
+	WinBuiltinPerfMonitoringUsersSid            = 57
+	WinBuiltinPerfLoggingUsersSid               = 58
+	WinBuiltinAuthorizationAccessSid            = 59
+	WinBuiltinTerminalServerLicenseServersSid   = 60
+	WinBuiltinDCOMUsersSid                      = 61
+	WinBuiltinIUsersSid                         = 62
+	WinIUserSid                                 = 63
+	WinBuiltinCryptoOperatorsSid                = 64
+	WinUntrustedLabelSid                        = 65
+	WinLowLabelSid                              = 66
+	WinMediumLabelSid                           = 67
+	WinHighLabelSid                             = 68
+	WinSystemLabelSid                           = 69
+	WinWriteRestrictedCodeSid                   = 70
+	WinCreatorOwnerRightsSid                    = 71
+	WinCacheablePrincipalsGroupSid              = 72
+	WinNonCacheablePrincipalsGroupSid           = 73
+	WinEnterpriseReadonlyControllersSid         = 74
+	WinAccountReadonlyControllersSid            = 75
+	WinBuiltinEventLogReadersGroup              = 76
+	WinNewEnterpriseReadonlyControllersSid      = 77
+	WinBuiltinCertSvcDComAccessGroup            = 78
+	WinMediumPlusLabelSid                       = 79
+	WinLocalLogonSid                            = 80
+	WinConsoleLogonSid                          = 81
+	WinThisOrganizationCertificateSid           = 82
+	WinApplicationPackageAuthoritySid           = 83
+	WinBuiltinAnyPackageSid                     = 84
+	WinCapabilityInternetClientSid              = 85
+	WinCapabilityInternetClientServerSid        = 86
+	WinCapabilityPrivateNetworkClientServerSid  = 87
+	WinCapabilityPicturesLibrarySid             = 88
+	WinCapabilityVideosLibrarySid               = 89
+	WinCapabilityMusicLibrarySid                = 90
+	WinCapabilityDocumentsLibrarySid            = 91
+	WinCapabilitySharedUserCertificatesSid      = 92
+	WinCapabilityEnterpriseAuthenticationSid    = 93
+	WinCapabilityRemovableStorageSid            = 94
+)
+
+var (
+	procCreateWellKnownSid = advapi32.MustFindProc("CreateWellKnownSid")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446585.aspx
+func CreateWellKnownSid(sidType int32, sidDomain, sid *windows.SID, sidLen *uint32) error {
+	ret, _, err := procCreateWellKnownSid.Call(
+		uintptr(sidType),
+		uintptr(unsafe.Pointer(sidDomain)),
+		uintptr(unsafe.Pointer(sid)),
+		uintptr(unsafe.Pointer(sidLen)),
+	)
+	if ret == 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/hectane/go-acl/apply.go
+++ b/vendor/github.com/hectane/go-acl/apply.go
@@ -1,0 +1,55 @@
+//+build windows
+
+package acl
+
+import (
+	"github.com/hectane/go-acl/api"
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// Apply the provided access control entries to a file. If the replace
+// parameter is true, existing entries will be overwritten. If the inherit
+// parameter is true, the file will inherit ACEs from its parent.
+func Apply(name string, replace, inherit bool, entries ...api.ExplicitAccess) error {
+	var oldAcl windows.Handle
+	if !replace {
+		var secDesc windows.Handle
+		api.GetNamedSecurityInfo(
+			name,
+			api.SE_FILE_OBJECT,
+			api.DACL_SECURITY_INFORMATION,
+			nil,
+			nil,
+			&oldAcl,
+			nil,
+			&secDesc,
+		)
+		defer windows.LocalFree(secDesc)
+	}
+	var acl windows.Handle
+	if err := api.SetEntriesInAcl(
+		entries,
+		oldAcl,
+		&acl,
+	); err != nil {
+		return err
+	}
+	defer windows.LocalFree((windows.Handle)(unsafe.Pointer(acl)))
+	var secInfo uint32
+	if !inherit {
+		secInfo = api.PROTECTED_DACL_SECURITY_INFORMATION
+	} else {
+		secInfo = api.UNPROTECTED_DACL_SECURITY_INFORMATION
+	}
+	return api.SetNamedSecurityInfo(
+		name,
+		api.SE_FILE_OBJECT,
+		api.DACL_SECURITY_INFORMATION|secInfo,
+		nil,
+		nil,
+		acl,
+		0,
+	)
+}

--- a/vendor/github.com/hectane/go-acl/appveyor.yml
+++ b/vendor/github.com/hectane/go-acl/appveyor.yml
@@ -1,0 +1,16 @@
+version: '{build}'
+
+clone_folder: C:\gopath\src\github.com\hectane\go-acl
+
+environment:
+  GOPATH: C:\gopath
+
+install:
+  - go version
+  - go env
+  - go get -t -v ./...
+
+build: off
+
+test_script:
+  - go test -v ./...

--- a/vendor/github.com/hectane/go-acl/chmod.go
+++ b/vendor/github.com/hectane/go-acl/chmod.go
@@ -1,0 +1,38 @@
+//+build windows
+
+package acl
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// Change the permissions of the specified file. Only the nine
+// least-significant bytes are used, allowing access by the file's owner, the
+// file's group, and everyone else to be explicitly controlled.
+func Chmod(name string, fileMode os.FileMode) error {
+	// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+	creatorOwnerSID, err := windows.StringToSid("S-1-3-0")
+	if err != nil {
+		return err
+	}
+	creatorGroupSID, err := windows.StringToSid("S-1-3-1")
+	if err != nil {
+		return err
+	}
+	everyoneSID, err := windows.StringToSid("S-1-1-0")
+	if err != nil {
+		return err
+	}
+
+	mode := uint32(fileMode)
+	return Apply(
+		name,
+		true,
+		false,
+		GrantSid(((mode&0700)<<23)|((mode&0200)<<9), creatorOwnerSID),
+		GrantSid(((mode&0070)<<26)|((mode&0020)<<12), creatorGroupSID),
+		GrantSid(((mode&0007)<<29)|((mode&0002)<<15), everyoneSID),
+	)
+}

--- a/vendor/github.com/hectane/go-acl/go.mod
+++ b/vendor/github.com/hectane/go-acl/go.mod
@@ -1,0 +1,5 @@
+module github.com/hectane/go-acl
+
+go 1.12
+
+require golang.org/x/sys v0.0.0-20190529164535-6a60838ec259

--- a/vendor/github.com/hectane/go-acl/go.sum
+++ b/vendor/github.com/hectane/go-acl/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259 h1:so6Hr/LodwSZ5UQDu/7PmQiDeS112WwtLvU3lpSPZTU=
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/hectane/go-acl/posix.go
+++ b/vendor/github.com/hectane/go-acl/posix.go
@@ -1,0 +1,8 @@
+//+build !windows
+
+package acl
+
+import "os"
+
+// Chmod is os.Chmod.
+var Chmod = os.Chmod

--- a/vendor/github.com/hectane/go-acl/util.go
+++ b/vendor/github.com/hectane/go-acl/util.go
@@ -1,0 +1,62 @@
+//+build windows
+
+package acl
+
+import (
+	"github.com/hectane/go-acl/api"
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// Create an ExplicitAccess instance granting permissions to the provided SID.
+func GrantSid(accessPermissions uint32, sid *windows.SID) api.ExplicitAccess {
+	return api.ExplicitAccess{
+		AccessPermissions: accessPermissions,
+		AccessMode:        api.GRANT_ACCESS,
+		Inheritance:       api.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: api.Trustee{
+			TrusteeForm: api.TRUSTEE_IS_SID,
+			Name:        (*uint16)(unsafe.Pointer(sid)),
+		},
+	}
+}
+
+// Create an ExplicitAccess instance granting permissions to the provided name.
+func GrantName(accessPermissions uint32, name string) api.ExplicitAccess {
+	return api.ExplicitAccess{
+		AccessPermissions: accessPermissions,
+		AccessMode:        api.GRANT_ACCESS,
+		Inheritance:       api.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: api.Trustee{
+			TrusteeForm: api.TRUSTEE_IS_NAME,
+			Name:        windows.StringToUTF16Ptr(name),
+		},
+	}
+}
+
+// Create an ExplicitAccess instance denying permissions to the provided SID.
+func DenySid(accessPermissions uint32, sid *windows.SID) api.ExplicitAccess {
+	return api.ExplicitAccess{
+		AccessPermissions: accessPermissions,
+		AccessMode:        api.DENY_ACCESS,
+		Inheritance:       api.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: api.Trustee{
+			TrusteeForm: api.TRUSTEE_IS_SID,
+			Name:        (*uint16)(unsafe.Pointer(sid)),
+		},
+	}
+}
+
+// Create an ExplicitAccess instance denying permissions to the provided name.
+func DenyName(accessPermissions uint32, name string) api.ExplicitAccess {
+	return api.ExplicitAccess{
+		AccessPermissions: accessPermissions,
+		AccessMode:        api.DENY_ACCESS,
+		Inheritance:       api.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: api.Trustee{
+			TrusteeForm: api.TRUSTEE_IS_NAME,
+			Name:        windows.StringToUTF16Ptr(name),
+		},
+	}
+}


### PR DESCRIPTION
This sets correct access control for the ssh key
and makes openssh on windows able to use the key
without any "permission are too open error"

based on 616cfa21e62076d5c0f567eecec156b98af2804c