### PR TITLE
drivers/virtualbox: Follow symlinks on FreeBSD

### DIFF
--- a/drivers/virtualbox/virtualbox_freebsd.go
+++ b/drivers/virtualbox/virtualbox_freebsd.go
@@ -1,11 +1,18 @@
 package virtualbox
 
+import "path/filepath"
+
 func detectVBoxManageCmd() string {
 	return detectVBoxManageCmdInPath()
 }
 
 func getShareDriveAndName() (string, string) {
-	return "hosthome", "/home"
+	path, err := filepath.EvalSymlinks("/home")
+	if err != nil {
+		path = "/home"
+	}
+
+	return "hosthome", path
 }
 
 func isHyperVInstalled() bool {


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

The VirtualBox driver on FreeBSD is hard coded to "/home" and does not follow it if it's a symbolic link. This breaks minikube if "/home" is a symbolic link. 

## Related issue(s)

None